### PR TITLE
fixed overdue task logic

### DIFF
--- a/app/src/main/java/com/evanv/taskapp/logic/LogicSubsystem.java
+++ b/app/src/main/java/com/evanv/taskapp/logic/LogicSubsystem.java
@@ -161,6 +161,7 @@ public class LogicSubsystem {
         // As the user has marked these tasks as completed, remove them.
         for (int i = 0; i < completedItems.size(); i++) {
             Complete(overdueTasks.get(completedItems.get(i)));
+            mTaskAppViewModel.delete(overdueTasks.get(completedItems.get(i)));
         }
 
         // Change due date for overdue tasks if it has already been passed to today.
@@ -247,7 +248,10 @@ public class LogicSubsystem {
             task.getParents().get(i).removeChild(task);
         }
 
-        DayItemHelper(diff);
+
+        if (diff >= 0) {
+            DayItemHelper(diff);
+        }
     }
 
     /**

--- a/app/src/main/java/com/evanv/taskapp/ui/main/MainActivity.java
+++ b/app/src/main/java/com/evanv/taskapp/ui/main/MainActivity.java
@@ -165,6 +165,12 @@ public class MainActivity extends AppCompatActivity implements ClickListener {
 
         mLogicSubsystem = new LogicSubsystem(this, todayTime);
 
+        // Create activity result handler for AddItem
+        mStartForResult = registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(),
+                result -> MainActivity.this.onActivityResult(result.getResultCode(),
+                        result.getData()));
+
         String[] overdueNames = mLogicSubsystem.getOverdueTasks();
 
         // Prompt the user with a dialog containing overdue tasks so they can mark overdue tasks
@@ -261,11 +267,6 @@ public class MainActivity extends AppCompatActivity implements ClickListener {
             mVF.setDisplayedChild(2);
         }
 
-        // Create activity result handler for AddItem
-        mStartForResult = registerForActivityResult(
-                new ActivityResultContracts.StartActivityForResult(),
-                result -> MainActivity.this.onActivityResult(result.getResultCode(),
-                        result.getData()));
     }
 
     /**


### PR DESCRIPTION
Overdue task logic previously crashed as it created startActivityForResult in the wrong point in the lifcecycle. Additionally, it was not properly deleting overdue tasks from it's database. Closes #67 